### PR TITLE
Settings : Add country code to blacklist entry dialog

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -6,7 +6,8 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
 	android-support-v4 \
 	android-support-v13 \
 	jsr305 \
-	org.cyanogenmod.platform.internal
+	org.cyanogenmod.platform.internal \
+	libphonenumber
 
 LOCAL_MODULE_TAGS := optional
 

--- a/res/layout/dialog_blacklist_edit_entry.xml
+++ b/res/layout/dialog_blacklist_edit_entry.xml
@@ -31,6 +31,20 @@
         android:paddingStart="10dip"
         android:paddingEnd="10dip">
 
+        <LinearLayout android:id="@+id/country_code_layout"
+            android:visibility="gone"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <TextView android:text="@string/blacklist_country_code_plus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <Spinner android:id="@+id/number_country_code"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal" />
+        </LinearLayout>
+
         <EditText android:id="@+id/number_edit"
             android:layout_width="0dip"
             android:layout_weight="1"

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -1246,5 +1246,5 @@
     <string name="lockscreen_wallpaper_title">Wallpaper</string>
 
     <string name="not_available_with_app">Not available with %1$s</string>
-
+    <string name="blacklist_country_code_plus" translateable="false">+</string>
 </resources>


### PR DESCRIPTION
Enforce country code when adding an entry. If the user has regex enabled,
- is added to the list as a choice. This avoids the confusion users are currently
  facing where blocking only the number + regex doesn't work, since country code is expected.

Eg :

206\* won't work
+1206\* works

CYNGNOS-3049
BACON-4953

Change-Id: I9236898f17fcef425e561aaa10e56c5e8c2171a7
